### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
 
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.


### PR DESCRIPTION
Potential fix for [https://github.com/runesuy/2XD2-Engine/security/code-scanning/1](https://github.com/runesuy/2XD2-Engine/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block to scope down the GITHUB_TOKEN privileges to only what the workflow needs. Since this workflow only checks out code and builds/tests it, it only requires read access to repository contents. We can set `permissions: contents: read` either at the top level (for all jobs) or at the specific job. To keep the change minimal and aligned with the CodeQL suggestion, we will add a job-level `permissions:` block under `jobs.build`, alongside `runs-on`.

Concretely, in `.github/workflows/cmake-multi-platform.yml`, under `jobs: build:`, insert:

```yaml
    permissions:
      contents: read
```

with indentation matching the existing `runs-on` key. No imports or additional definitions are needed since this is pure workflow configuration. This change will ensure that the `build` job runs with a read-only GITHUB_TOKEN for contents and will satisfy the CodeQL rule without altering the current functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
